### PR TITLE
Add tokio for more responsive I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anstream"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -47,6 +62,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -59,16 +89,21 @@ name = "burstshark"
 version = "0.1.0"
 dependencies = [
  "clap",
- "ctrlc",
- "macaddr",
  "nix",
+ "tokio",
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.79"
+name = "bytes"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "cc"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 
 [[package]]
 name = "cfg-if"
@@ -130,17 +165,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
 dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
-dependencies = [
- "nix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -151,7 +176,7 @@ checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -163,6 +188,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "heck"
@@ -184,7 +215,7 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -196,14 +227,14 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "linux-raw-sys"
@@ -212,10 +243,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
 
 [[package]]
-name = "macaddr"
-version = "1.0.1"
+name = "memchr"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -224,6 +255,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -241,10 +292,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -254,9 +330,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -271,6 +347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +363,16 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -308,6 +399,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,12 +439,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -334,13 +468,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -350,10 +499,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -362,10 +523,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -374,13 +547,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ description = "BurstShark is a network traffic analysis tool that wraps around t
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.2.0", features = ["derive", "env"] }
-ctrlc = "3.2.5"
-macaddr = "1.0.1"
-nix = "0.26.2"
+clap = { version = "4.2.0", features = ["derive"] }
+nix = { version = "0.26.2", features = ["signal"] }
+tokio = { version = "1.37.0", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # BurstShark
 
-**Note: README not yet complete**
-
 BurstShark is a network traffic analysis tool that wraps around tshark to identify and analyze bursty application data traffic, such as adaptive streaming, in real-time or from pcap files. It captures application data packets and frames and records their sizes, creating bursts that happen within a small window of time. The output of the program consists of a line for each burst between two addresses and/or port. In the case of WLAN capture, such as when using monitor mode, MAC addresses will be displayed instead of IP addresses.
 
 Each output line contains the following information:
 
 * Burst counter (incremental)
-* Completion time of the burst (relative or epoch time)
+* Completion time (s) of the burst relative to the program start
 * Source IP or MAC address
-* Source port (or empty no port)
+* Source port (0 if no port)
 * Destination IP or MAC address
-* Destination port (or empty if no port)
-* Start time of the burst (relative or epoch time)
-* End time of the burst (relative or epoch time)
+* Destination port (0 if no port)
+* Unix timestamp of the first packet in the burst
+* Unix timestamp of the last packet in the burst
+* Delay (s) between BurstShark reporting the burst and its last packet
 * Number of packets in the burst
 * Total size (in bytes) of the burst
 
@@ -29,39 +28,35 @@ Usage: burstshark [OPTIONS]
 
 Options:
   -i, --interface <INTERFACE>
-          Network interface to use for live capture. First non-loopback interface if no interface or file supplied
+          Network interface to use for live capture
+  -f, --capture-filter <CAPTURE_FILTER>
+          Packet filter for live capture in libpcap filter syntax
+  -s, --snapshot-length <SNAPLEN>
+          Number of bytes to capture per packet during live capture [default: 96]
   -r, --read-file <INFILE>
           Read packet data from infile
-  -f, --capture-filter <CAPTURE_FILTER>
-          Packet filter in libpcap filter syntax. Merged with default for data packets
   -Y, --display-filter <DISPLAY_FILTER>
-          Packet filter in Wireshark display filter syntax. Merged with default for data packets
-  -t, --inactive-time <INACTIVE_TIME>
-          Seconds with no activity to consider a new burst [default: 1]
-  -p, --ignore-ports
-          Ignore ports when and create bursts based on IP addresses only
-  -w, --write-capture <CAPTURE_OUTFILE>
-          Write captured packets by tshark to a capture file
-  -W, --write-bursts <BURSTS_OUTFILE>
-          Write output from BurstShark to a file
-  -q, --suppress
-          Don't display bursts on the standard output
+          Packet filter in Wireshark display filter syntax
+  -t, --burst_timeout <BURST_TIMEOUT>
+          Seconds with no flow activity for a burst to be considered complete [default: 0.5]
+  -a, --aggregate-ports
+          Aggregate ports for flows with the same IP src/dst pair to a single flow
+  -w, --write-pcap <PCAP_OUTFILE>
+          Write raw packet data read by tshark to pcap_outfile
   -b, --min-bytes <MIN_BYTES>
-          Only display bursts with a minimum amount of bytes
+          Only display bursts with a minimum size of min_bytes
   -B, --max-bytes <MAX_BYTES>
-          Only display bursts with a maximum amount of bytes
-  -n, --min-packets <MIN_PACKETS>
-          Only display bursts with a minimum amount of packets/frames
-  -N, --max-packets <MAX_PACKETS>
-          Only display bursts with a maximum amount of packets/frames
-  -T, --time-format <TIME_FORMAT>
-          Which time format to use for output [default: relative] [possible values: relative, epoch]
-  -I, --monitor-mode
-          Capture 802.11 WLAN frames instead of IP packets
-  -G, --no-guess
-          Disable guessing sizes of WLAN data frames missed by the monitor mode device
+          Only display bursts with a maximum size of max_bytes
+  -p, --min-packets <MIN_PACKETS>
+          Only display bursts with a minimum amount of min_packets packets/frames
+  -P, --max-packets <MAX_PACKETS>
+          Only display bursts with a maximum amount of max_packets packets/frames
+  -I, --wlan
+          Read 802.11 WLAN QoS data frames instead of IP packets
+  -E, --no-estimation
+          Disable frame size estimation for missed WLAN frames
   -M, --max-deviation <MAX_DEVIATION>
-          Maximum allowed deviation from the expected sequence number for WLAN frames [default: 50]
+          Maximum allowed deviation from the expected WLAN sequence number [default: 200]
   -h, --help
           Print help (see more with '--help')
   -V, --version

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,55 +1,54 @@
-use std::{
-    collections::HashMap,
-    error::Error,
-    io::BufRead,
-    net::IpAddr,
-    process::{Command, Stdio},
-    str::FromStr,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        mpsc::Sender,
-        Arc,
-    },
-};
+use std::collections::{hash_map::Entry, HashMap};
+use std::error::Error;
+use std::process::Stdio;
 
-use macaddr::MacAddr;
-use nix::sys::signal;
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
+
+const FLOW_TIMEOUT: f64 = 30.0;
+
+type FlowKey = (String, String, u16, u16);
 
 #[derive(Debug, Clone)]
 pub struct Burst {
-    pub completion_time: f64,
     pub src: String,
     pub dst: String,
-    pub src_port: Option<u16>,
-    pub dst_port: Option<u16>,
+    pub src_port: u16,
+    pub dst_port: u16,
     pub start: f64,
     pub end: f64,
     pub num_packets: u16,
     pub size: u32,
 }
 
+#[derive(Debug, Clone)]
 pub struct CommonOptions {
     pub tshark_args: Vec<String>,
     pub inactive_time: f64,
-    pub tx: Sender<Burst>,
+    pub output_tx: mpsc::Sender<Burst>,
 }
 
+#[derive(Debug, Clone)]
 pub enum CaptureType {
-    IPCapture {
+    Ip {
         opts: CommonOptions,
         ignore_ports: bool,
     },
-    WLANCapture {
+    Wlan {
         opts: CommonOptions,
-        no_guess: bool,
+        no_estimation: bool,
         max_deviation: u16,
     },
 }
 
 impl CaptureType {
-    pub fn run(&self) -> Result<(), Box<dyn Error>> {
+    pub async fn run(&self) -> Result<(), Box<dyn Error>> {
         let opts = match self {
-            CaptureType::IPCapture { opts, .. } | CaptureType::WLANCapture { opts, .. } => opts,
+            CaptureType::Ip { opts, .. } | CaptureType::Wlan { opts, .. } => opts,
         };
 
         let mut tshark = Command::new("tshark")
@@ -57,245 +56,310 @@ impl CaptureType {
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
-            .map_err(|err| format!("Failed to start tshark: {err}"))?;
+            .map_err(|err| format!("failed to start tshark: {}", err))?;
 
-        // Set up interrupt handler (ctrl-c)
-        let running = Arc::new(AtomicBool::new(true));
-        let r = running.clone();
-        let tshark_pid = tshark.id() as i32;
-        ctrlc::set_handler(move || {
-            r.store(false, Ordering::SeqCst);
-            let pid = nix::unistd::Pid::from_raw(tshark_pid);
-            signal::kill(pid, signal::Signal::SIGINT).expect("Failed to send SIGINT to tshark");
-        })?;
+        if let Some(tshark_pid) = tshark.id() {
+            let tshark_pid = tshark_pid as i32;
+            tokio::spawn(async move {
+                tokio::signal::ctrl_c().await.unwrap();
+                kill(Pid::from_raw(tshark_pid), Signal::SIGTERM).unwrap();
+            });
+        }
 
         let stdout = tshark.stdout.take().unwrap();
-        let reader = std::io::BufReader::new(stdout);
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
 
-        match self {
-            CaptureType::IPCapture { ignore_ports, .. } => {
-                let mut flows: HashMap<(IpAddr, IpAddr, Option<u16>, Option<u16>), IpFlow> =
-                    HashMap::new();
-                for line in reader.lines() {
-                    let packet = match IpPacket::from_tshark(&line.unwrap()) {
-                        Ok(packet) => packet,
-                        Err(_) => continue,
-                    };
-                    let flow_key = if *ignore_ports {
-                        (packet.src, packet.dst, None, None)
-                    } else {
-                        (
-                            packet.src,
-                            packet.dst,
-                            Some(packet.src_port),
-                            Some(packet.dst_port),
-                        )
-                    };
-                    flows
-                        .entry(flow_key)
-                        .and_modify(|flow| flow.add_packet(&packet, &opts.tx, opts.inactive_time))
-                        .or_insert_with(|| IpFlow::new(&packet, *ignore_ports));
-                }
-            }
-            CaptureType::WLANCapture {
-                no_guess,
-                max_deviation,
-                ..
-            } => {
-                let mut flows: HashMap<(MacAddr, MacAddr), WlanFlow> = HashMap::new();
-                for line in reader.lines() {
-                    let packet = match WlanPacket::from_tshark(&line.unwrap()) {
-                        Ok(packet) => packet,
-                        Err(_) => continue,
-                    };
-                    flows
-                        .entry((packet.src, packet.dst))
-                        .and_modify(|flow| flow.add_packet(&packet, &opts.tx, opts.inactive_time))
-                        .or_insert_with(|| WlanFlow::new(&packet, *no_guess, *max_deviation));
-                }
+        let mut flows = HashMap::<FlowKey, mpsc::Sender<Packet>>::new();
+        let (timeout_tx, mut timeout_rx) = mpsc::channel::<FlowKey>(100);
+
+        loop {
+            tokio::select! {
+                line = lines.next_line() => {
+                    match line? {
+                        Some(line) => {
+                            let packet = Packet::from_tshark(&line, self).map_err(|err| {
+                                format!("failed to parse packet: {}", err)
+                            })?;
+
+                            let flow_key = (
+                                packet.src.clone(),
+                                packet.dst.clone(),
+                                packet.src_port,
+                                packet.dst_port,
+                            );
+
+                            match flows.entry(flow_key) {
+                                Entry::Occupied(mut entry) => {
+                                    entry.get_mut().send(packet).await?;
+                                },
+
+                                Entry::Vacant(entry) => {
+                                    let flow_key = entry.key().clone();
+                                    let capture_type = self.clone();
+                                    let (packet_tx, packet_rx) = mpsc::channel(100);
+                                    let timeout_tx = timeout_tx.clone();
+
+                                    tokio::spawn(async move {
+                                        flow_handler(flow_key, &capture_type, packet_rx, timeout_tx).await;
+                                    });
+
+                                    entry.insert(packet_tx).send(packet).await?;
+                                },
+                            }
+                        },
+
+                        None => break,
+                    }
+                },
+
+                Some(flow_key) = timeout_rx.recv() => {
+                    // Remove flow. Drops sender and causes its flow_handler to exit.
+                    flows.remove(&flow_key);
+                },
             }
         }
 
-        tshark.wait()?;
+        tshark.wait().await?;
+
         Ok(())
     }
 }
 
-struct IpPacket {
+async fn flow_handler(
+    flow_key: FlowKey,
+    capture_type: &CaptureType,
+    mut rx: mpsc::Receiver<Packet>,
+    timeout_tx: mpsc::Sender<FlowKey>,
+) {
+    let opts = match capture_type {
+        CaptureType::Ip { opts, .. } | CaptureType::Wlan { opts, .. } => opts,
+    };
+
+    let burst_timeout = Duration::from_secs_f64(opts.inactive_time);
+    let flow_timeout = Duration::from_secs_f64(FLOW_TIMEOUT);
+
+    let mut flow = create_flow(capture_type);
+
+    loop {
+        let burst = flow.get_current_burst();
+
+        let timeout = if burst.is_some() {
+            sleep(burst_timeout)
+        } else {
+            sleep(flow_timeout)
+        };
+
+        tokio::select! {
+            _ = timeout => {
+                if let Some(burst) = burst {
+                    opts.output_tx.send(burst.clone()).await.unwrap();
+                    flow.reset_burst();
+                    continue;
+                }
+
+                // Flow has timed out due to inactivity.
+                // Will continue until None is received due to dropped sender.
+                timeout_tx.send(flow_key.clone()).await.unwrap();
+            },
+
+            packet = rx.recv() => {
+                match packet {
+                    Some(packet) => {
+                        if let Some(burst) = burst {
+                            // If packet timestamps do not correlate with program time,
+                            // e.g. due to file read, check if burst is ready.
+                            if packet.time - burst.end > opts.inactive_time {
+                                opts.output_tx.send(burst.clone()).await.unwrap();
+                                flow.reset_burst();
+                            }
+                        }
+
+                        flow.add_packet(&packet);
+                    },
+
+                    None => break,
+                }
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Packet {
     time: f64,
-    src: IpAddr,
-    dst: IpAddr,
+    src: String,
+    dst: String,
+    data_len: u32,
     src_port: u16,
     dst_port: u16,
-    data_len: u32,
+    seq_number: Option<u16>,
 }
 
-struct WlanPacket {
-    time: f64,
-    src: MacAddr,
-    dst: MacAddr,
-    data_len: u32,
-    seq_number: u16,
-}
-
-struct IpFlow {
-    ignore_ports: bool,
-    current_burst: Burst,
-}
-
-struct WlanFlow {
-    current_burst: Burst,
-    expected_seq_number: u16,
-    last_packet_len: u32,
-    no_guess: bool,
-    max_deviation: u16,
-}
-
-impl IpPacket {
-    fn from_tshark(line: &str) -> Result<Self, Box<dyn Error>> {
+impl Packet {
+    fn from_tshark(line: &str, capture_type: &CaptureType) -> Result<Self, Box<dyn Error>> {
         let mut fields = line.split_whitespace();
-        Ok(IpPacket {
-            time: fields.next().unwrap().parse::<f64>()?,
-            src: IpAddr::from_str(fields.next().unwrap())?,
-            dst: IpAddr::from_str(fields.next().unwrap())?,
-            src_port: fields.next().unwrap().parse::<u16>()?,
-            dst_port: fields.next().unwrap().parse::<u16>()?,
-            data_len: fields.next().unwrap().parse::<u32>()?,
+
+        let time = fields.next().ok_or("no time")?.parse::<f64>()?;
+        let src = fields.next().ok_or("no source")?;
+        let dst = fields.next().ok_or("no destination")?;
+        let data_len = fields.next().ok_or("no length")?.parse::<u32>()?;
+
+        let (mut src_port, mut dst_port, mut seq_number) = (0, 0, None);
+
+        match capture_type {
+            CaptureType::Ip { ignore_ports, .. } if !ignore_ports => {
+                src_port = fields.next().ok_or("no source port")?.parse::<u16>()?;
+                dst_port = fields.next().ok_or("no destination port")?.parse::<u16>()?;
+            }
+            CaptureType::Wlan { .. } => {
+                seq_number = Some(fields.next().ok_or("no sequence number")?.parse::<u16>()?);
+            }
+            _ => {}
+        }
+
+        Ok(Packet {
+            time,
+            src: src.to_string(),
+            dst: dst.to_string(),
+            data_len,
+            src_port,
+            dst_port,
+            seq_number,
         })
-    }
-}
-
-impl WlanPacket {
-    fn from_tshark(line: &str) -> Result<Self, Box<dyn Error>> {
-        let mut fields = line.split_whitespace();
-        Ok(WlanPacket {
-            time: fields.next().unwrap().parse::<f64>()?,
-            src: MacAddr::from_str(fields.next().unwrap())?,
-            dst: MacAddr::from_str(fields.next().unwrap())?,
-            data_len: fields.next().unwrap().parse::<u32>()?,
-            seq_number: fields.next().unwrap().parse::<u16>()?,
-        })
-    }
-}
-
-impl IpFlow {
-    fn new(p: &IpPacket, ignore_ports: bool) -> Self {
-        IpFlow {
-            ignore_ports,
-            current_burst: Burst::from_ip_packet(p, ignore_ports),
-        }
-    }
-
-    fn add_packet(&mut self, p: &IpPacket, tx: &Sender<Burst>, inactive_time: f64) {
-        if p.time - self.current_burst.end > inactive_time {
-            self.current_burst.completion_time = p.time;
-            tx.send(self.current_burst.clone()).unwrap();
-            self.current_burst = Burst::from_ip_packet(p, self.ignore_ports);
-        } else {
-            self.current_burst.end = p.time;
-            self.current_burst.num_packets += 1;
-            self.current_burst.size += p.data_len;
-        }
-    }
-}
-
-impl WlanFlow {
-    fn new(p: &WlanPacket, no_guess: bool, max_deviation: u16) -> Self {
-        WlanFlow {
-            current_burst: Burst::from_wlan_packet(p),
-            expected_seq_number: p.seq_number,
-            last_packet_len: p.data_len,
-            no_guess,
-            max_deviation,
-        }
-    }
-
-    fn add_packet(&mut self, p: &WlanPacket, tx: &Sender<Burst>, inactive_time: f64) {
-        if p.time - self.current_burst.end > inactive_time {
-            self.current_burst.completion_time = p.time;
-            tx.send(self.current_burst.clone()).unwrap();
-            self.current_burst = Burst::from_wlan_packet(p);
-
-            // Accept sequence number of packet after the inactive time.
-            self.expected_seq_number = (p.seq_number + 1) & 4095;
-            self.last_packet_len = p.data_len;
-        } else {
-            // Packet sequence number is what we expect.
-            if p.seq_number == self.expected_seq_number {
-                self.expected_seq_number = (p.seq_number + 1) & 4095;
-                self.last_packet_len = p.data_len;
-                self.current_burst.end = p.time;
-                self.current_burst.num_packets += 1;
-                self.current_burst.size += p.data_len;
-                return;
-            }
-
-            // Packet sequence number not what we expect.
-            let diff = (p.seq_number as i16 - self.expected_seq_number as i16) & 4095;
-            let signed_diff = if diff <= 2048 { diff } else { diff - 4096 };
-
-            // We already added this packet, but it is probably being retransmitted.
-            // Note: not enough to filter on the retransmission bit as the first frame might be lost.
-            if -(self.max_deviation as i16) < signed_diff && signed_diff < 0 {
-                self.current_burst.end = p.time;
-                return;
-            }
-
-            // The packet has a sequence number that is further along than what we expect.
-            // Monitor mode device might have missed frames.
-            if 0 < signed_diff && signed_diff < self.max_deviation as i16 {
-                if !self.no_guess {
-                    // Guess the lengths of the lost frames
-                    let guess = (self.last_packet_len + p.data_len) / 2;
-                    self.current_burst.num_packets += diff as u16;
-                    self.current_burst.size += guess * diff as u32;
-                } else {
-                    // Accept only this
-                    self.current_burst.num_packets += 1;
-                    self.current_burst.size += p.data_len;
-                }
-                // Bring the expected sequence number in line with the packet.
-                self.expected_seq_number = (p.seq_number + 1) & 4095;
-                self.last_packet_len = p.data_len;
-                self.current_burst.end = p.time;
-            } else {
-                // In case of a larger deviation, might be a single outlier, go to next expected.
-                self.expected_seq_number = (self.expected_seq_number + 1) & 4095;
-            }
-        }
     }
 }
 
 impl Burst {
-    fn from_ip_packet(p: &IpPacket, ignore_ports: bool) -> Self {
-        let (src_port, dst_port) = if ignore_ports {
-            (None, None)
-        } else {
-            (Some(p.src_port), Some(p.dst_port))
-        };
+    fn from_packet(p: &Packet) -> Self {
         Burst {
-            completion_time: p.time,
-            src: p.src.to_string(),
-            dst: p.dst.to_string(),
-            src_port,
-            dst_port,
+            src: p.src.clone(),
+            dst: p.dst.clone(),
+            src_port: p.src_port,
+            dst_port: p.dst_port,
             start: p.time,
             end: p.time,
             num_packets: 1,
             size: p.data_len,
         }
     }
-    fn from_wlan_packet(p: &WlanPacket) -> Self {
-        Burst {
-            completion_time: p.time,
-            src: p.src.to_string(),
-            dst: p.dst.to_string(),
-            src_port: None,
-            dst_port: None,
-            start: p.time,
-            end: p.time,
-            num_packets: 1,
-            size: p.data_len,
+}
+
+trait Flow: Send {
+    fn add_packet(&mut self, p: &Packet);
+    fn get_current_burst(&self) -> &Option<Burst>;
+    fn reset_burst(&mut self);
+}
+
+fn create_flow(capture_type: &CaptureType) -> Box<dyn Flow> {
+    match capture_type {
+        CaptureType::Ip { .. } => Box::new(IpFlow {
+            current_burst: None,
+        }),
+
+        CaptureType::Wlan { .. } => Box::new(WlanFlow {
+            no_estimation: false,
+            max_deviation: 0,
+            expected_seq_number: 0,
+            last_packet_len: 0,
+            current_burst: None,
+        }),
+    }
+}
+
+struct IpFlow {
+    current_burst: Option<Burst>,
+}
+
+impl Flow for IpFlow {
+    fn add_packet(&mut self, p: &Packet) {
+        if self.current_burst.is_none() {
+            self.current_burst = Some(Burst::from_packet(p));
+            return;
         }
+
+        let burst = self.current_burst.as_mut().unwrap();
+
+        burst.end = p.time;
+        burst.num_packets += 1;
+        burst.size += p.data_len;
+    }
+
+    fn get_current_burst(&self) -> &Option<Burst> {
+        &self.current_burst
+    }
+
+    fn reset_burst(&mut self) {
+        self.current_burst = None;
+    }
+}
+
+struct WlanFlow {
+    no_estimation: bool,
+    max_deviation: u16,
+    expected_seq_number: u16,
+    last_packet_len: u32,
+    current_burst: Option<Burst>,
+}
+
+impl Flow for WlanFlow {
+    fn add_packet(&mut self, p: &Packet) {
+        if self.current_burst.is_none() {
+            self.current_burst = Some(Burst::from_packet(p));
+            self.expected_seq_number = (p.seq_number.unwrap() + 1) & 4095;
+            self.last_packet_len = p.data_len;
+            return;
+        }
+
+        let burst = self.current_burst.as_mut().unwrap();
+        let seq_number = p.seq_number.unwrap();
+
+        if seq_number == self.expected_seq_number {
+            self.expected_seq_number = (seq_number + 1) & 4095;
+            self.last_packet_len = p.data_len;
+            burst.end = p.time;
+            burst.num_packets += 1;
+            burst.size += p.data_len;
+            return;
+        }
+
+        // Sequence number not what we expect.
+        let diff = (seq_number as i16 - self.expected_seq_number as i16) & 4095;
+        let signed_diff = if diff <= 2048 { diff } else { diff - 4096 };
+
+        // Check if frame already added. Could be a retransmission.
+        // Not enough to filter on the retransmission bit as the first frame might be lost.
+        if -(self.max_deviation as i16) < signed_diff && signed_diff < 0 {
+            burst.end = p.time;
+            return;
+        }
+
+        // Sequence number is further along than what we expect. Could be lost frame(s).
+        if 0 < signed_diff && signed_diff < self.max_deviation as i16 {
+            if !self.no_estimation {
+                let estimate = (self.last_packet_len + p.data_len) / 2;
+                burst.num_packets += diff as u16;
+                burst.size += estimate * diff as u32;
+            } else {
+                // Accept only this frame if estimation is disabled.
+                burst.num_packets += 1;
+                burst.size += p.data_len;
+            }
+            // Bring the expected sequence number in line with the new frame.
+            self.expected_seq_number = (seq_number + 1) & 4095;
+            self.last_packet_len = p.data_len;
+            burst.end = p.time;
+        } else {
+            // Larger deviation than allowed, go to next expected.
+            self.expected_seq_number = (self.expected_seq_number + 1) & 4095;
+        }
+    }
+
+    fn get_current_burst(&self) -> &Option<Burst> {
+        &self.current_burst
+    }
+
+    fn reset_burst(&mut self) {
+        self.current_burst = None;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+#![forbid(unsafe_code)]
+
+pub mod capture;
+pub mod output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,69 +8,92 @@ use burstshark::output::OutputWriter;
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about)]
 struct Args {
-    /// Network interface to use for live capture. First non-loopback interface if no interface or file supplied.
+    /// Network interface to use for live capture.
+    ///
+    /// Uses first non-loopback interface if no interface or file supplied.
     #[clap(short = 'i', long = "interface")]
     interface: Option<String>,
 
-    /// Packet filter in libpcap filter syntax. Merged with default for data packets.
+    /// Packet filter for live capture in libpcap filter syntax.
+    ///
+    /// Merged with a default filter that captures UDP and TCP packets with payload,
+    /// or QoS data WLAN frames if WLAN is enabled.
     #[clap(short = 'f', long = "capture-filter", conflicts_with = "infile")]
     capture_filter: Option<String>,
 
-    /// Number of bytes to capture per packet. Default is 96 bytes, enough to capture relevant headers.
-    /// A value of 0 captures the entire packet.
+    /// Number of bytes to capture per packet during live capture.
+    ///
+    /// No more than snaplen bytes of each packet will be read into memory, or saved. The
+    /// default value is configured to capture relevant headers / packet length information
+    /// required for BurstShark. A snaplen of 0 will capture the entire packet.
     #[clap(
         short = 's',
         long = "snapshot-length",
         default_value_t = 96,
         conflicts_with = "infile"
     )]
-    snapshot_length: u32,
+    snaplen: u32,
 
     /// Read packet data from infile.
+    ///
+    /// Can be any capture file format supported by tshark, including gzipped files.
     #[clap(short = 'r', long = "read-file", conflicts_with = "interface")]
     infile: Option<String>,
 
-    /// Packet filter in Wireshark display filter syntax. Merged with default for data packets.
-    #[clap(short = 'Y', long = "display-filter", requires = "infile")]
+    /// Packet filter in Wireshark display filter syntax.
+    ///
+    /// Can be used for both live capture and reading from a file. Less efficient than a
+    /// capture filter for live capture so it is recommended to move as much of the
+    /// filtering logic as possible to the capture filter.
+    #[clap(short = 'Y', long = "display-filter")]
     display_filter: Option<String>,
 
-    /// Seconds with no activity to consider a new burst.
-    #[clap(short = 't', long = "inactive-time", default_value_t = 1.0)]
-    inactive_time: f64,
+    /// Seconds with no flow activity for a burst to be considered complete.
+    #[clap(short = 't', long = "burst_timeout", default_value_t = 0.5)]
+    burst_timeout: f64,
 
-    /// Ignore ports when and create bursts based on IP addresses only.
-    #[clap(short = 'p', long = "ignore-ports", conflicts_with = "wlan")]
-    ignore_ports: bool,
+    /// Aggregate ports for flows with the same IP src/dst pair to a single flow.
+    ///
+    /// If enabled, output bursts will have a source and destination port of 0.
+    #[clap(short = 'a', long = "aggregate-ports", conflicts_with = "wlan")]
+    aggregate_ports: bool,
 
-    /// Write captured packets by tshark to a capture file.
-    #[clap(short = 'w', long = "write-capture")]
-    capture_outfile: Option<String>,
+    /// Write raw packet data read by tshark to pcap_outfile.
+    #[clap(short = 'w', long = "write-pcap")]
+    pcap_outfile: Option<String>,
 
-    /// Only display bursts with a minimum amount of bytes.
+    /// Only display bursts with a minimum size of min_bytes.
     #[clap(short = 'b', long = "min-bytes")]
     min_bytes: Option<u32>,
 
-    /// Only display bursts with a maximum amount of bytes.
+    /// Only display bursts with a maximum size of max_bytes.
     #[clap(short = 'B', long = "max-bytes")]
     max_bytes: Option<u32>,
 
-    /// Only display bursts with a minimum amount of packets/frames.
-    #[clap(short = 'n', long = "min-packets")]
+    /// Only display bursts with a minimum amount of min_packets packets/frames.
+    #[clap(short = 'p', long = "min-packets")]
     min_packets: Option<u16>,
 
-    /// Only display bursts with a maximum amount of packets/frames.
-    #[clap(short = 'N', long = "max-packets")]
+    /// Only display bursts with a maximum amount of max_packets packets/frames.
+    #[clap(short = 'P', long = "max-packets")]
     max_packets: Option<u16>,
 
     /// Read 802.11 WLAN QoS data frames instead of IP packets.
+    ///
+    /// For live capture, the interface should be in monitor mode.
     #[clap(short = 'I', long = "wlan")]
     wlan: bool,
 
-    /// Disable estimating sizes of WLAN frames missed by the capture device.
+    /// Disable frame size estimation for missed WLAN frames.
+    ///
+    /// By default, missed WLAN frames will have their sizes estimated based on the
+    /// average size of the frames captured.
     #[clap(short = 'E', long = "no-estimation", requires = "wlan")]
     no_estimation: bool,
 
-    /// Maximum allowed deviation from the expected sequence number for WLAN frames.
+    /// Maximum allowed deviation from the expected WLAN sequence number.
+    ///
+    /// Only frames within max_deviation will be considered and estimated.
     #[clap(
         short = 'M',
         long = "max-deviation",
@@ -95,7 +118,6 @@ fn tshark_args(args: Args) -> Vec<String> {
             "-e", "ip.dst",
             "-e", "ipv6.dst",
             "-e", "data.len",
-            "-e", "quic.length",
             "-e", "udp.length",
             "-e", "tcp.len",
             "-e", "udp.srcport",
@@ -112,7 +134,7 @@ fn tshark_args(args: Args) -> Vec<String> {
         ],
     });
 
-    let default_filter = match (&args.infile, &args.wlan) {
+    let base_filter = match (&args.infile, &args.wlan) {
         (None, false) => String::from(
             "udp or (tcp and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0))",
         ),
@@ -121,28 +143,38 @@ fn tshark_args(args: Args) -> Vec<String> {
         (Some(_), true) => String::from("wlan and wlan.fc.type_subtype == 40"),
     };
 
-    let filter = match args
-        .capture_filter
-        .or(args.display_filter)
-        .or(args.positional_filter.map(|f| f.join(" ")))
-    {
-        Some(filter) => format!("({}) and ({})", default_filter, filter),
-        None => default_filter,
+    let create_filter = |optional_filter: Option<String>| -> Option<String> {
+        match optional_filter.or(args.positional_filter.map(|f| f.join(" "))) {
+            Some(filter) => Some(format!("({}) and ({})", base_filter, filter)),
+            None => Some(base_filter),
+        }
     };
 
-    let snapshot_length = args.snapshot_length.to_string();
+    let (capture_filter, display_filter) = match &args.infile {
+        None => (create_filter(args.capture_filter), args.display_filter),
+        Some(_) => (None, create_filter(args.display_filter)),
+    };
 
-    tshark_args.extend(match &args.infile {
-        Some(infile) => vec!["-Y", &filter, "-r", infile],
-        None => vec!["-s", &snapshot_length, "-f", &filter],
-    });
+    let snapshot_length = args.snaplen.to_string();
+
+    if let Some(capture_filter) = &capture_filter {
+        tshark_args.extend(vec!["-s", &snapshot_length, "-f", capture_filter]);
+    }
+
+    if let Some(display_filter) = &display_filter {
+        tshark_args.extend(vec!["-Y", display_filter]);
+    }
 
     if let Some(interface) = &args.interface {
         tshark_args.extend(vec!["-i", interface]);
     }
 
-    if let Some(capture_outfile) = &args.capture_outfile {
-        tshark_args.extend(vec!["-w", capture_outfile, "-P"]);
+    if let Some(infile) = &args.infile {
+        tshark_args.extend(vec!["-r", infile]);
+    }
+
+    if let Some(pcap_outfile) = &args.pcap_outfile {
+        tshark_args.extend(vec!["-w", pcap_outfile, "-P"]);
     }
 
     tshark_args.into_iter().map(str::to_string).collect()
@@ -163,14 +195,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let opts = CommonOptions {
         tshark_args: tshark_args(args.clone()),
-        inactive_time: args.inactive_time,
+        burst_timeout: args.burst_timeout,
         output_tx,
     };
 
     match args.wlan {
         false => CaptureType::Ip {
             opts,
-            ignore_ports: args.ignore_ports,
+            aggregate_ports: args.aggregate_ports,
         },
         true => CaptureType::Wlan {
             opts,


### PR DESCRIPTION
Previously, outputting a burst for a flow was considered synchronously only when a new packet associated with the flow arrived. Bursts would thus take longer to be reported due to needing a new packet on the flow. This adds asynchronous handling of flows and checking if bursts should be output, via the tokio runtime.

This also includes some other changes and fixes. See the README for program options and output format.
